### PR TITLE
Make "raw" with full dictionary hits entirely optional

### DIFF
--- a/src/Docs.ts
+++ b/src/Docs.ts
@@ -585,8 +585,15 @@ function AddDocComponent({old, done}: AddDocProps) {
             const sha1 = old.sha1s[remidx];
             const a = old.annotated[sha1];
 
-            // get raw corresponding to sha1 from database
-            const raw = await db.get<RawAnalysis>(docLineRawToKey(old.unique, sha1));
+            // get raw corresponding to sha1 from database. Might be missing if
+            // 1- the raw never existed (for non-Japanese lines) or
+            // 2- the local PouchDB was hydrated without this optional data.
+            // In case of #2, we could fetch the raw from the NLP server as we do elsewhere.
+            // For simplicity, just assume #1.
+            let raw: RawAnalysis|undefined;
+            try {
+              raw = await db.get<RawAnalysis>(docLineRawToKey(old.unique, sha1));
+            } catch { raw = undefined; }
 
             for (const [fidx, f] of (a ? a.furigana : []).entries()) {
               if (f) {

--- a/src/Docs.ts
+++ b/src/Docs.ts
@@ -252,6 +252,11 @@ async function getDocs(singleDocUnique = ''): Promise<Docs> {
           for (const annotatedOuter of annots.rows) {
             const annotated = annotatedOuter.doc;
             if (annotated) {
+              if (annotated.furigana.length === 0) {
+                // legacy: annotation used to be created for plain text. let's delete these
+                db.upsert(annotatedOuter.id, () => ({_deleted: true}));
+                continue;
+              }
               if (annotated.furigana.some(f => !f)) {
                 // oops, we might need to refresh the furigana from raws because >0 annotated furiganas was undefined
                 const raw = await db.get<RawAnalysis|undefined>(docLineRawToKey(u, annotated.sha1));

--- a/src/Docs.ts
+++ b/src/Docs.ts
@@ -1,5 +1,5 @@
 import './Docs.css';
-const NLP_SERVER = 'http://127.0.0.1:8133/api/v1/sentences';
+const NLP_SERVER = 'https://curtiz-japanese-nlp.glitch.me/api/v1/sentences';
 
 /************
 Data model

--- a/src/Docs.ts
+++ b/src/Docs.ts
@@ -558,7 +558,7 @@ function AddDocComponent({old, done}: AddDocProps) {
               furigana: response.furigana,
               kanjidic: response.kanjidic,
             };
-            annotated[sha1] = {sha1, text, hits: [], furigana: response.furigana};
+            annotated[sha1] = {sha1, text, hits: [], furigana: response.furigana.slice()};
           }
         }
 
@@ -603,8 +603,10 @@ function AddDocComponent({old, done}: AddDocProps) {
             const newRaw = raws[sha1s[addidx]];
             if (newAnnotated && newRaw) {
               // reintroduce furigana if both base and top raws match
-              newAnnotated.furigana = newRaw.furigana.map(
-                  f => (baseToFuri.get(furiganaToBase(f)) && topToFuri.get(furiganaToTop(f))) || []);
+              for (const [idx, f] of newRaw.furigana.entries()) {
+                const override = baseToFuri.has(furiganaToBase(f)) ? topToFuri.get(furiganaToTop(f)) : undefined;
+                if (override) { newAnnotated.furigana[idx] = override; }
+              }
 
               // reintroduce hits if run present
               const newHaystack = newRaw.furigana.map(furiganaToBase);

--- a/src/Docs.ts
+++ b/src/Docs.ts
@@ -26,7 +26,7 @@ type Furigana = string|Ruby;
 interface AnnotatedAnalysis {
   sha1: string;
   text: string;
-  furigana: Furigana[][]; // overrides for each morpheme
+  furigana: (Furigana[]|undefined)[]; // overrides for each morpheme
   hits: AnnotatedHit[];   // hits can span morphemes, so no constraints on this length
 }
 interface RawAnalysis {
@@ -698,7 +698,7 @@ const SentenceComponent = observer(function SentenceComponent({lineNumber, doc}:
   return ce(
       'p', {id: `${doc.unique}-${lineNumber}`},
       ...furigana
-          .map((morpheme, midx) => annotated?.furigana[midx] || doc.overrides[furiganaToBase(morpheme)] || morpheme)
+          .map(morpheme => morpheme ? doc.overrides[furiganaToBase(morpheme)] || morpheme : ['missing'])
           .flatMap((v, i) => v.map(o => {
             const onClick = async () => {
               const click: ClickedMorpheme = {

--- a/src/Docs.ts
+++ b/src/Docs.ts
@@ -647,7 +647,7 @@ function AddDocComponent({old, done}: AddDocProps) {
           if (done) { done(); }
         });
       } else {
-        console.error('error parsing sentences: ' + res.statusText);
+        console.error('error parsing sentences');
       }
     })
   },

--- a/src/Docs.ts
+++ b/src/Docs.ts
@@ -164,6 +164,8 @@ db.changes({since: 'now', live: true, include_docs: true})
       gotandaStore.loggedIn = res.ok;
       if (text) { gotandaStore.serverMessage = text; }
     })
+    // if we're not logged in, don't even try to sync or other stuff
+    if (!res.ok) { return; }
   }
 
   const KANDA_APP_NAME = 'kanda-mobx2';

--- a/src/Docs.ts
+++ b/src/Docs.ts
@@ -591,7 +591,7 @@ function AddDocComponent({old, done}: AddDocProps) {
             for (const [fidx, f] of (a ? a.furigana : []).entries()) {
               if (f) {
                 baseToFuri.set(furiganaToBase(f), f);
-                topToFuri.set(furiganaToTop(raw?.furigana[fidx] || []), f);
+                topToFuri.set(furiganaToTop(raw?.furigana[fidx] || ['<none>']), f);
               }
             }
             for (const h of (a ? a.hits : [])) {


### PR DESCRIPTION
Benefits of making the app fully functional without this `raw` data (dictionary hits, furigana, and KanjiDic):

- much faster loading: currently, with a few thousand lines of Japanese text, Firefox will semi-freeze for several seconds on page load (it'll still scroll, but won't respond to clicks or selections)
- much lighter data export (21 MB → 996 KB)
- no change in functionality if connected to network

Notes:

- the raw data is still stored in the local PouchDB, *and* persisted to Gotanda backend and other logged-in devices!
- However, when a device is loaded from just the Kanda-exported app (just the document data, without any raw analysis), this won't be available, but the app remains fully functional if connected because we'll call the Curtiz Japanese NLP server to reparse the sentence.